### PR TITLE
Fix/ansi test output

### DIFF
--- a/.github/workflows/docker.image.yml
+++ b/.github/workflows/docker.image.yml
@@ -126,7 +126,7 @@ jobs:
           docker buildx imagetools inspect localhost:5000/foobar/${{ env.IMAGE_NAME }}
       - name: Test the Docker image
         run: |
-          CONTAINER_OUTPUT=$(docker run --rm -t localhost:5000/foobar/${{ env.IMAGE_NAME }} -h)
+          CONTAINER_OUTPUT=$(docker run --rm localhost:5000/foobar/${{ env.IMAGE_NAME }} -h)
           echo "Container output: $CONTAINER_OUTPUT"
           echo "Container output (quoted): '$CONTAINER_OUTPUT'"
 


### PR DESCRIPTION
## Summary by Sourcery

Update Docker base image and related tooling, and adjust the CI test invocation for container output.

Build:
- Bump Docker base image from Alpine 3.23.4 to 3.24.1.
- Update SPEEDTEST_CLI package default version used in the image build.

CI:
- Change the Docker image test workflow to run the container without a TTY to simplify captured output.